### PR TITLE
Added license information

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -14,6 +14,7 @@
         <description lang="en">Videos from cultural, natural, scientific, academic, technical and other heritage organisations from across the world.[CR][CR]70 channels for v1.0.2.[CR][CR]This addon depends upon the Youtube addon by Bromix (http://kodi.wiki/view/Add-on:YouTube), so install that as well.
         </description>
         <platform>all</platform>
+        <license>GNU GENERAL PUBLIC LICENSE. Version 3, 29 June 2007</license>
         <forum>http://forum.kodi.tv/showthread.php?tid=235754</forum>
         <source>https://github.com/ookgezellig/plugin.video.heritagechannel</source>
         <email>ookgezellig at gmail</email>


### PR DESCRIPTION
Needed to automatically fill the links on http://kodi.wiki and http://addons.kodi.tv/ sites.
